### PR TITLE
Create changeImportPath function

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,6 @@
     "dependencies": {
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "ts-morph": "^17.0.0"
+        "ts-morph": "^17.0.1"
     }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,13 +21,13 @@ specifiers:
   prettier: ^2.7.1
   react: ^18.2.0
   react-dom: ^18.2.0
-  ts-morph: ^17.0.0
+  ts-morph: ^17.0.1
   typescript: ^4.9.3
 
 dependencies:
   react: 18.2.0
   react-dom: 18.2.0_react@18.2.0
-  ts-morph: 17.0.0
+  ts-morph: 17.0.1
 
 devDependencies:
   '@babel/core': 7.20.2
@@ -4292,8 +4292,8 @@ packages:
     dependencies:
       is-number: 7.0.0
 
-  /ts-morph/17.0.0:
-    resolution: {integrity: sha512-EJxyHTpBXsYnOgV6UpYs4vjhMS/8IZXg5kkGcM9+b8SygMmmOoeWOpaSG8E4puhewjkIbUObodGhfJkBoFX3og==}
+  /ts-morph/17.0.1:
+    resolution: {integrity: sha512-10PkHyXmrtsTvZSL+cqtJLTgFXkU43Gd0JCc0Rw6GchWbqKe0Rwgt1v3ouobTZwQzF1mGhDeAlWYBMGRV7y+3g==}
     dependencies:
       '@ts-morph/common': 0.18.0
       code-block-writer: 11.0.3

--- a/src/functions/changeImportPath/changeImportPath.test.ts
+++ b/src/functions/changeImportPath/changeImportPath.test.ts
@@ -1,0 +1,99 @@
+import { stripIndent } from 'common-tags';
+import { changeImportPath } from './changeImportPath';
+import { createSourceFile } from '../../tests/helpers';
+
+it('changes the import path for a default import', () => {
+    const file = createSourceFile(`
+        import foo from '@module/bar';
+    `);
+
+    const modifiedFile = changeImportPath(
+        file,
+        'foo',
+        '@module/bar',
+        '@module/baz'
+    );
+
+    expect(modifiedFile?.getText()).toEqual(
+        stripIndent(`
+            import foo from '@module/baz';
+        `)
+    );
+});
+
+it('changes the import path for a single named import', () => {
+    const file = createSourceFile(`
+        import { foo } from '@module/bar';
+    `);
+
+    const modifiedFile = changeImportPath(
+        file,
+        'foo',
+        '@module/bar',
+        '@module/baz'
+    );
+
+    expect(modifiedFile?.getText()).toEqual(
+        stripIndent(`
+            import { foo } from '@module/baz';
+        `)
+    );
+});
+
+it('adds a new import path for a named import, if needed', () => {
+    const file = createSourceFile(`
+        import { foo, other } from '@module/bar';
+    `);
+
+    const modifiedFile = changeImportPath(
+        file,
+        'foo',
+        '@module/bar',
+        '@module/baz'
+    );
+
+    expect(stripIndent(modifiedFile.getText())).toEqual(
+        stripIndent(`
+            import { other } from '@module/bar';
+            import { foo } from '@module/baz';
+        `)
+    );
+});
+
+it('does not change the import path if the source does not match', () => {
+    const file = createSourceFile(`
+        import { foo } from '@module/foo';
+    `);
+
+    const modifiedFile = changeImportPath(
+        file,
+        'foo',
+        '@module/bar',
+        '@module/baz'
+    );
+
+    expect(stripIndent(modifiedFile.getText())).toEqual(
+        stripIndent(`
+            import { foo } from '@module/foo';
+        `)
+    );
+});
+
+it('does not change the import path if the identifier is not imported', () => {
+    const file = createSourceFile(`
+        import { bar } from '@module/bar';
+    `);
+
+    const modifiedFile = changeImportPath(
+        file,
+        'foo',
+        '@module/bar',
+        '@module/baz'
+    );
+
+    expect(stripIndent(modifiedFile.getText())).toEqual(
+        stripIndent(`
+            import { bar } from '@module/bar';
+        `)
+    );
+});

--- a/src/functions/changeImportPath/changeImportPath.ts
+++ b/src/functions/changeImportPath/changeImportPath.ts
@@ -1,0 +1,56 @@
+import { SourceFile } from 'ts-morph';
+
+/**
+ * Modify the import module specifier for a given import
+ * Works best with absolute imports, as this function only compares strings
+ * In the future, an alternative function could accept SourceFile parameters
+ * */
+export function changeImportPath(
+    file: SourceFile,
+    importIdentifier: string,
+    currentImportSource: string,
+    newImportSource: string
+) {
+    const modifiedFile = file;
+
+    // Get import that matches currentImportSource
+    const imp = modifiedFile.getImportDeclaration(
+        (i) => i.getModuleSpecifierValue() === currentImportSource
+    );
+
+    if (!imp) {
+        return modifiedFile;
+    }
+
+    const namedImports = imp.getNamedImports();
+
+    // If a named import exists
+    if (namedImports.length) {
+        namedImports.forEach((i) => {
+            // Check if we have a matching named import
+            if (i.getName() === importIdentifier) {
+                // If only one named import, change the module specifier
+                if (namedImports.length === 1) {
+                    imp.setModuleSpecifier(newImportSource);
+                } else {
+                    // Otherwise, create a new import declaration
+                    i.remove();
+                    modifiedFile.addImportDeclaration({
+                        namedImports: [importIdentifier],
+                        moduleSpecifier: newImportSource,
+                    });
+                }
+            }
+        });
+    }
+
+    const defaultImport = imp.getDefaultImport();
+
+    // If a default import exists
+    if (defaultImport) {
+        // There can only be one import, so change the module specifier
+        imp.setModuleSpecifier(newImportSource);
+    }
+
+    return modifiedFile;
+}

--- a/src/tests/helpers/createSourceFile.tsx
+++ b/src/tests/helpers/createSourceFile.tsx
@@ -1,9 +1,14 @@
 import { stripIndent } from 'common-tags';
-import { Project } from 'ts-morph';
+import { Project, QuoteKind } from 'ts-morph';
 
 // Helper function to create a source file in a fake ts-morph project
 export function createSourceFile(source: string) {
-    const project = new Project({});
+    const project = new Project({
+        manipulationSettings: {
+            quoteKind: QuoteKind.Single,
+        },
+    });
+
     return project.createSourceFile(
         // TSX to support JSX
         'test.tsx',


### PR DESCRIPTION
This PR creates the `changeImportPath` function.

Also updates ts-morph, per the error in [this issue](https://www.github.com/dsherret/ts-morph/issues/1357).